### PR TITLE
chore: migrate type tests to TSTyche

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,9 @@
         "@babel/runtime": "^7.21.0"
       },
       "devDependencies": {
-        "@tsd/typescript": "^5.7.2",
-        "jest-tsd": "^0.2.2",
         "rete": "^2.0.1",
-        "rete-cli": "^2.0.2"
+        "rete-cli": "^2.0.2",
+        "tstyche": "^3.2.0"
       },
       "peerDependencies": {
         "rete": "^2.0.1"
@@ -2719,15 +2718,6 @@
         "minimatch": "^9.0.4",
         "mkdirp": "^3.0.1",
         "path-browserify": "^1.0.1"
-      }
-    },
-    "node_modules/@tsd/typescript": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-Xuhtk1h4T35XXJWWKmufMV1UMK1C5aMA+3AYDgkQgiaR4lLS+7lNXOEC0lDancspFO9SOZzASpfOvUoATm2cPA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@types/babel__core": {
@@ -5563,20 +5553,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/jest-tsd": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/jest-tsd/-/jest-tsd-0.2.2.tgz",
-      "integrity": "sha512-Nzgo5E9F1RON3GDkAHxVOf1dqSSRMnhJ5txULHhhK+qs2xSLmLWBbtYjKSlAYNpW/fOXSrGPOs6uE0YyWAchhA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.21.4",
-        "chalk": "^4.1.2",
-        "tsd-lite": "^0.7.0"
-      },
-      "peerDependencies": {
-        "@tsd/typescript": "4.x || 5.x"
-      }
-    },
     "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -7408,24 +7384,35 @@
         "typescript": "2 || 3 || 4 || 5"
       }
     },
-    "node_modules/tsd-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/tsd-lite/-/tsd-lite-0.7.0.tgz",
-      "integrity": "sha512-XhQ7w/RPzfjSb98LIQB1qx7yAvRV6+h5JFP4dCvd79Hbp23X8CCx4EdRAQm6faTkRdprKYvZE8kxlK6LpJp8vg==",
-      "deprecated": "'tsd-lite' is deprecated. For details, see the deprecation notice: https://github.com/mrazauskas/tsd-lite/issues/364",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@tsd/typescript": "4.x || 5.x"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
+    },
+    "node_modules/tstyche": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tstyche/-/tstyche-3.2.0.tgz",
+      "integrity": "sha512-Dx02zXctfHIAk9gxCspMFvflg8lfGPQVHq63wyu+4qcKiqnlorBCtZMhShP51+q/YygsmiqKytehNC0jgprODw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tstyche": "build/bin.js"
+      },
+      "engines": {
+        "node": ">=18.19"
+      },
+      "funding": {
+        "url": "https://github.com/tstyche/tstyche?sponsor=1"
+      },
+      "peerDependencies": {
+        "typescript": "4.x || 5.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,9 @@
     "rete": "^2.0.1"
   },
   "devDependencies": {
-    "@tsd/typescript": "^5.7.2",
-    "jest-tsd": "^0.2.2",
     "rete": "^2.0.1",
-    "rete-cli": "^2.0.2"
+    "rete-cli": "^2.0.2",
+    "tstyche": "^3.2.0"
   },
   "dependencies": {
     "@babel/runtime": "^7.21.0"

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,42 +1,36 @@
-import { describe, it } from '@jest/globals'
-import { expectType } from 'jest-tsd'
 import { ClassicPreset, NodeEditor } from 'rete'
+import { describe, expect, it } from 'tstyche'
 
 import { Dataflow } from '../src/dataflow'
 import { DataflowEngine, DataflowEngineScheme, DataflowNode } from '../src/dataflow-engine'
 import { ClassicScheme } from '../src/types'
 
 describe('Dataflow types', () => {
-  let editor!: NodeEditor<ClassicScheme>
-  let dataflow: Dataflow<ClassicScheme>
-
-  beforeEach(() => {
-    editor = new NodeEditor<ClassicScheme>()
-    dataflow = new Dataflow(editor)
-  })
+  const editor = new NodeEditor<ClassicScheme>()
+  const dataflow = new Dataflow(editor)
 
   it('returns default Record type for node data', () => {
     const node = new ClassicPreset.Node('label')
 
-    expectType<Promise<Record<string, any>>>(dataflow.fetch(node.id))
+    expect(dataflow.fetch(node.id)).type.toBe<Promise<Record<string, any>>>()
   })
 
   it('returns default Record type for node inputs', () => {
     const node = new ClassicPreset.Node('label')
 
-    expectType<Promise<Record<string, any>>>(dataflow.fetchInputs(node.id))
+    expect(dataflow.fetchInputs(node.id)).type.toBe<Promise<Record<string, any>>>()
   })
 
   it('accepts fetch data type as generic parameter', () => {
     const node = new ClassicPreset.Node('label')
 
-    expectType<Promise<{ a: string }>>(dataflow.fetch<{ a: string }>(node.id))
+    expect(dataflow.fetch<{ a: string }>(node.id)).type.toBe<Promise<{ a: string }>>()
   })
 
   it('accepts inputs data type as generic parameter', () => {
     const node = new ClassicPreset.Node('label')
 
-    expectType<Promise<{ a?: string[] }>>(dataflow.fetchInputs<{ a: string[] }>(node.id))
+    expect(dataflow.fetchInputs<{ a: string[] }>(node.id)).type.toBe<Promise<{ a?: string[] }>>()
   })
 })
 
@@ -50,22 +44,17 @@ class Node extends ClassicPreset.Node implements DataflowNode {
 }
 
 describe('DataflowEngine types', () => {
-  let editor!: NodeEditor<DataflowEngineScheme>
-  let dataflow: DataflowEngine<DataflowEngineScheme>
+  const editor = new NodeEditor<DataflowEngineScheme>()
+  const dataflow = new DataflowEngine()
 
-  beforeEach(() => {
-    editor = new NodeEditor<DataflowEngineScheme>()
-    dataflow = new DataflowEngine()
-
-    editor.use(dataflow)
-  })
+  editor.use(dataflow)
 
   it('returns default Record type for node data', async () => {
     const node1 = new Node('label1')
 
     const data = await dataflow.fetch(node1.id)
 
-    expectType<Record<string, any>>(data)
+    expect(data).type.toBe<Record<string, any>>()
   })
 
   it('returns default Record type fetch inputs', async () => {
@@ -73,7 +62,7 @@ describe('DataflowEngine types', () => {
 
     const data = await dataflow.fetchInputs(node1.id)
 
-    expectType<Record<string, any>>(data)
+    expect(data).type.toBe<Record<string, any>>()
   })
 
   it('returns custom type for node instance', async () => {
@@ -81,7 +70,7 @@ describe('DataflowEngine types', () => {
 
     const data = await dataflow.fetch(node1)
 
-    expectType<{ a: string, b: string }>(data)
+    expect(data).type.toBe<{ a: string, b: string }>()
   })
 
   it('returns custom type for genetic parameter', async () => {
@@ -89,7 +78,7 @@ describe('DataflowEngine types', () => {
 
     const data = await dataflow.fetch<Node>(node1)
 
-    expectType<{ a: string, b: string }>(data)
+    expect(data).type.toBe<{ a: string, b: string }>()
   })
 
   it('returns custom type for fetch inputs', async () => {
@@ -97,7 +86,7 @@ describe('DataflowEngine types', () => {
 
     const data = await dataflow.fetchInputs(node1)
 
-    expectType<{ a?: number[], b?: boolean[] }>(data)
+    expect(data).type.toBe<{ a?: number[], b?: boolean[] }>()
   })
 
   it('returns custom type for fetch inputs generic parameter', async () => {
@@ -105,6 +94,6 @@ describe('DataflowEngine types', () => {
 
     const data = await dataflow.fetchInputs<Node>(node1)
 
-    expectType<{ a?: number[], b?: boolean[] }>(data)
+    expect(data).type.toBe<{ a?: number[], b?: boolean[] }>()
   })
 })

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,6 +1,0 @@
-import { it } from '@jest/globals'
-import { expectTypeTestsToPassAsync } from 'jest-tsd'
-
-it('should not produce static type errors', async () => {
-  await expectTypeTestsToPassAsync(__filename)
-})

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://tstyche.org/schemas/config.json",
+  "testFileMatch": ["test/*.test-d.*"]
+}


### PR DESCRIPTION
### Description

To draw your attention, `jest-tsd` is using `tsd-lite` that is [deprecated](https://github.com/mrazauskas/tsd-lite/issues/364) for around a year. I was maintaining `tsd-lite` for some time. It was created to integrate with Jest via `jest-runner-tsd`.

I would recommend using TSTyche, because it is a dedicated type test runner. Initially I wanted to integrate it with Jest, but... How to make it possible to test using different versions of TypeScript? With TSTyche this is easy: `tstyche --target '>=5.0'`.

A stand alone type test runner proofed to be a better idea. For example, TSTyche has `test()` and `describe()` helpers with `.only` and `.skip`. These are working well with static analysis. But it does not ship anything like `before()`, `after()` or `test.each`, because are not relevant and even misleading in context of type testing. There is no code execution. That’s why.

TSTyche many more advantages. I will not manage to list them here. Look around the documentation website: https://tstyche.org
### Checklist

<!-- Mark the items that apply to this pull request -->

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [n/a] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [n/a] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [n/a] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes

`npx tstyche` does the job, but I don’t know how to integrate TSTyche with `rete-cli`. Leaving this for maintainers.